### PR TITLE
Add ci plan for myapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ Port forward the UI:
 kubectl -n argo port-forward deployment/argo-server 2746:2746
 ```
 
+Run the workflow for `myapp`:
+
+```
+./ci/test.sh
+```
+
+This workflow will:
+
+1. Clone the repository
+2. Build the image (rootless buildkit)
+3. Push it to the internal KinD registry
+4. Run RSpec tests in this image
+5. Run Cucumber tests in this image
+
 ### Getting Started
 
 ## Argo CD
@@ -95,3 +109,10 @@ kubectl -n argo port-forward deployment/argo-server 2746:2746
 ## Argo Events
 
 To kick off a workflow, CD, or Rollout, we use Argo Events.
+
+# References
+
+- https://github.com/argoproj/argo-workflows/blob/master/examples/buildkit-template.yaml
+- https://github.com/moby/buildkit
+- https://kind.sigs.k8s.io/docs/user/local-registry/
+- https://argoproj.github.io/argo-workflows/enhanced-depends-logic/

--- a/bin/functions
+++ b/bin/functions
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+repo_root() {
+  git rev-parse --show-toplevel
+}
+
+timestamp() {
+  date +"%Y_%m_%d_%I_%M_%s"
+}
+
+files_dir() {
+  echo "$(repo_root)/src/files"
+}
+
+log_dir() {
+  echo "$(repo_root)/tmp"
+}
+
+check_env(){
+  # evaluate given variable name to get its value
+  eval temp_var="\$$1"
+
+  # verify it has a non-empty value
+  if [ -z "${temp_var}" ]; then
+    echo "ENV VAR \"$1\" must be set. Try sourcing \"src/config.env\" and running this command again."
+    exit 1
+  fi
+}
+
+# Returns 0 if is gnu sed, otherwise it returns 1.
+is_gnu_sed() {
+  sed --version >/dev/null 2>&1
+}
+
+sed_in_place() {
+  if is_gnu_sed; then
+    sed "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
+announce(){
+  echo "------------------------------------"
+  echo "$1"
+  echo "------------------------------------"
+}
+
+# Runs a given command if debug is off.
+cmd() {
+    if [ "$DEBUG_LEVEL" = "false" ]; then
+        "$@"
+    fi
+}
+
+# Runs a given command if debug is on.
+debug_cmd() {
+    if [ "$DEBUG_LEVEL" = "true" ]; then
+        "$@"
+    fi
+}
+
+require_dap_net() {
+  check_env "DOCKER_NETWORK"
+  local dap_net_pid
+  dap_net_pid=$(docker network ls --quiet --filter name="$DOCKER_NETWORK")
+  if [[ -z "$dap_net_pid" ]]; then
+    echo "FATAL: docker network '$DOCKER_NETWORK' does not exist. It must be created before continuing."
+    exit 1
+  fi
+}
+
+# Runs docker-compose commands from the root of this repository
+compose() {
+  pushd "$(repo_root)" > /dev/null || return
+    docker-compose "$@"
+  popd > /dev/null || return
+}
+
+version() {
+  if [ ! -f "$(repo_root)/VERSION" ]; then
+    echo "0.0.0"
+  else
+    cat "$(repo_root)/VERSION"
+  fi
+}
+
+is_gnu_base_64() {
+  base64 --version >/dev/null 2>&1
+}
+
+# Assumes arg is a file path...
+base64_proxy() {
+  if is_gnu_base_64; then
+    base64 -w 0 "$@"
+  else
+    cat "$@" | base64 
+  fi
+}
+
+git_sha(){
+  git rev-parse --short HEAD
+}
+
+git_current_branch(){
+  git branch --show-current
+}

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+source "$(git rev-parse --show-toplevel)/bin/functions"
+
+main(){
+  REPO_NAME="https://github.com/codihuston/argo-tutorial"
+  BRANCH="$(git_current_branch)"
+  DOCKERFILE_DIR="src/myapp"
+  # Use the following path inside k8s, see: https://kind.sigs.k8s.io/docs/user/local-registry/
+  REGISTRY_PUSH="kind-registry:5000"
+  REGISTRY_PULL="localhost:5001"
+  IMAGE="myapp:$(git_sha)"
+
+  argo submit -n argo --watch "$(repo_root)/workflows/myapp/myapp.yaml" \
+    --parameter "repo=$REPO_NAME" \
+    --parameter "branch=$BRANCH" \
+    --parameter "path=$DOCKERFILE_DIR" \
+    --parameter "registry_push=$REGISTRY_PUSH" \
+    --parameter "registry_pull=$REGISTRY_PULL" \
+    --parameter "image=$IMAGE"
+}
+
+main "$@"

--- a/workflows/myapp/myapp.yaml
+++ b/workflows/myapp/myapp.yaml
@@ -1,0 +1,151 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: myapp-workflow-
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: repo
+        value: https://github.com/argoproj/argo-workflows
+      - name: branch
+        value: master
+      - name: path
+        value: test/e2e/images/argosay/v2
+      - name: registry_push
+        value: registry.tld
+      - name: registry_pull
+        value: registry.tld
+      - name: image
+        value: alexcollinsintuit/argosay:v2
+  volumeClaimTemplates:                 # define volume, same syntax as k8s Pod spec
+  - metadata:
+      name: work-dir                     # name of volume claim
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi                  # Gi => 1024 * 1024 * 1024
+  templates:
+    - name: main
+      inputs: {}
+      outputs: {}
+      metadata: {}
+      dag:
+        tasks:
+          - name: clone
+            template: clone
+            arguments:
+              parameters:
+                - name: repo
+                  value: '{{workflow.parameters.repo}}'
+                - name: branch
+                  value: '{{workflow.parameters.branch}}'
+          - name: image
+            template: image
+            arguments:
+              parameters:
+                - name: path
+                  value: '{{workflow.parameters.path}}'
+                - name: registry
+                  value: '{{workflow.parameters.registry_push}}'
+                - name: image
+                  value: '{{workflow.parameters.image}}'
+            depends: "(clone.Succeeded)"
+          - name: "rspec-tests"
+            template: unit-test
+            arguments:
+              parameters:
+              - name: registry
+                value: '{{workflow.parameters.registry_pull}}'
+              - name: image
+                value: '{{workflow.parameters.image}}'
+            depends: "(clone.Succeeded && image.Succeeded)"
+          - name: "cucumber-tests"
+            template: e2e-test
+            arguments:
+              parameters:
+              - name: registry
+                value: '{{workflow.parameters.registry_pull}}'
+              - name: image
+                value: '{{workflow.parameters.image}}'
+            depends: "(rspec-tests.Succeeded)"
+    - name: clone
+      inputs:
+        parameters:
+          - name: repo
+          - name: branch
+      outputs: {}
+      metadata: {}
+      container:
+        name: ''
+        image: alpine/git:v2.26.2
+        args:
+          - clone
+          - '--depth'
+          - '1'
+          - '--branch'
+          - '{{inputs.parameters.branch}}'
+          - '--single-branch'
+          - '{{inputs.parameters.repo}}'
+          - .
+        workingDir: /work
+        volumeMounts:
+          - name: work-dir
+            mountPath: /work
+    - name: image
+      inputs:
+        parameters:
+          - name: path
+          - name: registry
+          - name: image
+      outputs: {}
+      metadata: {}
+      container:
+        name: ''
+        image: moby/buildkit:v0.9.3-rootless
+        command:
+          - buildctl-daemonless.sh
+        args:
+          - build
+          - '--frontend'
+          - dockerfile.v0
+          - '--local'
+          - context=.
+          - '--local'
+          - dockerfile=.
+          - '--output'
+          - >-
+            type=image,name={{inputs.parameters.registry}}/{{inputs.parameters.image}},push=true,registry.insecure=true
+        workingDir: /work/{{inputs.parameters.path}}
+        env:
+          - name: BUILDKITD_FLAGS
+            value: '--oci-worker-no-process-sandbox'
+          # - name: DOCKER_CONFIG
+          #   value: /.docker
+        volumeMounts:
+          - name: work-dir
+            mountPath: /work
+          # - name: docker-config
+          #   mountPath: /.docker
+      # volumes:
+      #   - name: docker-config
+      #     secret:
+      #       secretName: docker-config
+    - name: unit-test
+      inputs:
+        parameters:
+        - name: registry
+        - name: image
+      container:
+        image: "{{inputs.parameters.registry}}/{{inputs.parameters.image}}"
+        command: ["rspec"]
+    - name: e2e-test
+      inputs:
+        parameters:
+        - name: registry
+        - name: image
+      container:
+        image: "{{inputs.parameters.registry}}/{{inputs.parameters.image}}"
+        command: ["rake", "cucumber"]
+


### PR DESCRIPTION
We now have a successful pipeline using Argo Workflows that does the following:

Run the workflow for `myapp`:

```
./ci/test.sh
```

This workflow will:

1. Clone the repository
2. Build the image (rootless buildkit)
3. Push it to the internal KinD registry
4. Run RSpec tests in this image
5. Run Cucumber tests in this image

> Note: there is some nuance to using [KinD with a local image registry](https://kind.sigs.k8s.io/docs/user/local-registry/).
> The solution is to use different paths when pushing images (from inside the cluster from the context of the buildkit
> image) and pulling them (from the context of a Pod).