### PR TITLE
Add argo cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ To demo Argo Workflow, Events, and CD.
 
 ### Prerequisites
 
-1. [Install Argo CLI](https://github.com/argoproj/argo-workflows/releases)
-2. [Kubernetes Cluster](https://kind.sigs.k8s.io/)
+1. [Install Argo Workflows CLI](https://github.com/argoproj/argo-workflows/releases)
+2. [Install Argo CD CLI](https://argo-cd.readthedocs.io/en/stable/cli_installation/)
+3. [Kubernetes Cluster](https://kind.sigs.k8s.io/)
 
 ## Create Sample App 
 
@@ -74,10 +75,12 @@ docker-compose run web rake cucumber
 
 ## Argo Workflow (CI)
 
+See: [Repo](https://github.com/argoproj/argo-workflows).
+
 Install and test a sample workflow:
 
 ```
-./install-argo-workflow.sh
+./bin/001-install-argo-workflow.sh
 ```
 
 Port forward the UI:
@@ -104,9 +107,43 @@ This workflow will:
 
 ## Argo CD
 
+See: [Repo](https://github.com/argoproj/argo-cd/releases).
+
+Argo CD runs inside of Kubernetes. It will sync a given repo to a Kubernetes
+cluster. So the workflow would be:
+
+1. Run a workflow to build, test, and publish your application container
+2. In Argo CD, register an application repo
+3. When it's time to deploy to production, make a change in the [repo](https://github.com/codihuston/argo-cd-tutorial)
+   that Argo CD is monitoring
+
+   Argo CD will then sync the manifests to the Kubernetes cluster.
+
+In reality, Argo Workflows would commit a change to the repo that Argo CD is
+watching once the workflow is successful. Argo CD automatically polls repos for
+changes every 3 minutes. You can configure this to use [webhooks instead](https://argo-cd.readthedocs.io/en/stable/operator-manual/webhook/#:~:text=Git%20Webhook%20Configuration-,Overview,Bitbucket%2C%20Bitbucket%20Server%20and%20Gogs.).
+
+Install `Argo CD` and configure it to sync the [myapp gitops repository](https://github.com/codihuston/argo-cd-tutorial).
+
+```
+./bin/002-install-argo-cd-and-deploy-myapp.sh
+```
+
+This script will automatically port forward the UI, but in the case that
+it doesn't (port forwarding seems to be flaky for me) you can run this command
+below:
+
+```
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
 ## Argo Rollouts
 
+See: [Repo](https://argo-rollouts.readthedocs.io/en/stable/)
+
 ## Argo Events
+
+See: [Repo](https://argoproj.github.io/argo-events/)
 
 To kick off a workflow, CD, or Rollout, we use Argo Events.
 

--- a/README.md
+++ b/README.md
@@ -103,14 +103,29 @@ This workflow will:
 4. Run RSpec tests in this image
 5. Run Cucumber tests in this image
 
-### Getting Started
+## Getting Started
+
+Argo Workflows, Argo CD, Argo Events, and Argo Rollouts typically all live on
+the same Kubernetes cluster.
+
+Kubernetes provides a common platform for deploying and managing containers,
+making it the natural choice for running Argo Workflows, Argo CD, and Argo
+Events. Having all of these components on the same cluster allows for easy
+integration and communication between them, enabling you to create a complete
+CI/CD automation platform that can be easily managed and scaled.
+
+It's possible to run Argo Workflows, Argo CD, and Argo Events on separate
+clusters, at the cost of increasing the complexity of the setup and would
+require additional infrastructure and network configuration to ensure
+communication between the clusters. In most cases, it's recommended to run all
+components on the same cluster for ease of use and management.
 
 ## Argo CD
 
 See: [Repo](https://github.com/argoproj/argo-cd/releases).
 
-Argo CD runs inside of Kubernetes. It will sync a given repo to a Kubernetes
-cluster. So the workflow would be:
+Argo CD runs inside of Kubernetes. It will sync a given repo (application state)
+to a Kubernetes cluster. So the workflow would be:
 
 1. Run a workflow to build, test, and publish your application container
 2. In Argo CD, register an application repo
@@ -137,15 +152,44 @@ below:
 kubectl port-forward svc/argocd-server -n argocd 8080:443
 ```
 
-## Argo Rollouts
-
-See: [Repo](https://argo-rollouts.readthedocs.io/en/stable/)
-
 ## Argo Events
 
 See: [Repo](https://argoproj.github.io/argo-events/)
 
+Argo Events is an event management solution for the Argo ecosystem. It can
+watch a number of external services for changes and trigger Workflows or CD.
+
 To kick off a workflow, CD, or Rollout, we use Argo Events.
+
+Argo Events can trigger both Argo Workflows and Argo CD.
+
+In one scenario, Argo Events can be used to trigger an Argo Workflow in response
+to a specific event. For example, you can configure Argo Events to trigger
+an Argo Workflow whenever a new image is pushed to a container registry. The
+Argo Workflow can then perform tasks such as building images, testing code,
+and deploying applications.
+
+In another scenario, Argo Workflows can trigger Argo CD by modifying the desired
+state of the applications being managed by Argo CD. For example, you can create
+an Argo Workflow that updates the source code or configuration of an
+application and commits the changes to the source repository. Argo CD is
+configured to continuously sync the desired state of the application with the
+actual state in the target environment, so when it detects changes in the source
+repository, it will trigger a redeployment of the updated application.
+
+In summary, Argo Events can trigger either Argo Workflows or Argo CD, depending
+on the desired automation scenario, and both Argo Workflows and Argo CD can be
+used together to automate complex CI/CD pipelines and continuously manage the
+desired state of your applications.
+
+## Argo Rollouts
+
+See: [Repo](https://argo-rollouts.readthedocs.io/en/stable/)
+
+
+Argo Rollouts provides advanced deployment capabilities for your applications,
+allowing you to perform progressive delivery and canary releases, automate
+rollbacks, and control traffic routing. 
 
 # References
 

--- a/bin/001-install-argo-workflow.sh
+++ b/bin/001-install-argo-workflow.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# References: https://argoproj.github.io/argo-workflows/quick-start/
 main(){
   ARGO_WORKFLOWS_VERSION="3.4.4"
   kubectl create namespace argo

--- a/bin/002-install-argo-cd-and-deploy-myapp.sh
+++ b/bin/002-install-argo-cd-and-deploy-myapp.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# References: https://argo-cd.readthedocs.io/en/stable/getting_started/
+main(){
+  ARGO_CD_VERSION="2.5.10"
+  APP_NAMESPACE="myapp"
+  ARGO_CD_NAMESPACE="argocd"
+  ARGO_SERVER="localhost:8080"
+  REPO="https://github.com/codihuston/argo-cd-tutorial.git"
+  SELECTOR="app.kubernetes.io/name=argocd-server"
+
+  kubectl create namespace argocd
+  kubectl apply -n "$ARGO_CD_NAMESPACE" -f https://raw.githubusercontent.com/argoproj/argo-cd/v$ARGO_CD_VERSION/manifests/install.yaml
+
+  while ! kubectl -n "$ARGO_CD_NAMESPACE" get secret argocd-initial-admin-secret;
+  do
+    echo "Waiting for secret to be available..."
+    sleep 1
+  done
+
+  admin_pwd=$(kubectl -n "$ARGO_CD_NAMESPACE" get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d; echo)
+
+  while [[ $(kubectl get pods -n "$ARGO_CD_NAMESPACE" -l "$SELECTOR" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "Waiting for for pod: $SELECTOR..." && sleep 1; done
+
+  echo "Port forwarding on localhost:8080..."
+  kubectl port-forward svc/argocd-server -n "$ARGO_CD_NAMESPACE" 8080:443 &
+
+  echo "ArgoCD Admin Username: admin"
+  echo "ArgoCD Admin Password: $admin_pwd"
+  argocd login "$ARGO_SERVER"
+
+  # Register the KinD cluster that we will deploy apps to
+  yes | argocd cluster add kind-kind
+
+  # Deploy an application
+  kubectl create ns "$APP_NAMESPACE"
+  argocd app create myapp  --repo "$REPO" --path myapp --dest-server https://kubernetes.default.svc --dest-namespace "$APP_NAMESPACE"
+}
+
+main "$@"


### PR DESCRIPTION
I'm a fan so far of how straight forward this is (once I've gotten a hang of it). The components of the Argo Ecosystem fit together pretty well so far. What's left is to integrate Argo Events and Rollouts, then to experiment with a more complex application.

Argo CD is responsible for syncing the state of a git repository to Kubernetes. So, you'd have a set of manifests in this gitops repo, and Argo CD would sync it to some Kubernetes cluster. Argo CD polls the repo every 3 minutes by default. You can configure webhooks (recommended): https://argo-cd.readthedocs.io/en/stable/operator-manual/webhook/

You can use Argo Events to subscribe to changes in a repository to then kick off a Workflow. The Workflow would, upon success, make a change to the gitops repo, which Argo CD would eventually sync to a Kubernetes cluster. You can use Argo Rollouts for advanced deployment scenarios, like blue/green, canary, etc. See: https://argo-rollouts.readthedocs.io/en/stable/